### PR TITLE
Enable LTO when compiling for launch_1

### DIFF
--- a/keyboards/system76/launch_1/rules.mk
+++ b/keyboards/system76/launch_1/rules.mk
@@ -34,6 +34,7 @@ RGBLIGHT_ENABLE = no        # Support for RGB backlight (conflicts with RGB_MATR
 RGB_MATRIX_ENABLE = WS2812  # Support for RGB matrix
 RGB_MATRIX_CUSTOM_KB = yes  # Allow custom keyboard effect
 USB_6KRO_ENABLE = no        # 6key Rollover
+LTO_ENABLE = yes            # Link-time optimization for smaller binary
 
 # Add System76 EC command interface
 SRC+=../system76_ec.c


### PR DESCRIPTION
From:
```
 * The firmware size is approaching the maximum - 27748/28672 (96%, 924 bytes free)
```
To:
```
 * The firmware size is fine - 24306/28672 (84%, 4366 bytes free)
```

I haven't actually tried flashing the firmware, since I don't have an AVR ISP (in case it caused problems).