### PR TITLE
Reduce brightness of rainbow backdrop in unlock pattern

### DIFF
--- a/keyboards/system76/launch_1/rgb_matrix_kb.inc
+++ b/keyboards/system76/launch_1/rgb_matrix_kb.inc
@@ -77,7 +77,7 @@ static bool unlocked(effect_params_t* params) {
         HSV hsv = {
             .h = i + unlocked_ticks,
             .s = 0xFF,
-            .v = RGB_MATRIX_MAXIMUM_BRIGHTNESS,
+            .v = 0x70,
         };
         for (uint8_t j = 0; j < unlocked_leds_count; j++) {
             if (i == unlocked_leds[j]) {


### PR DESCRIPTION
This should improve contrast. Darkening it further will eventually make it difficult to distinguish the animation from something the host could generate