### PR TITLE
Backlight keycodes matching EC behavior

### DIFF
--- a/keyboards/system76/system76_ec.c
+++ b/keyboards/system76/system76_ec.c
@@ -70,6 +70,10 @@ void system76_ec_unlock(void) {
     bootloader_unlocked = true;
 }
 
+bool system76_ec_is_unlocked(void) {
+    return bootloader_unlocked;
+}
+
 #if defined(RGB_MATRIX_CUSTOM_KB)
 enum Mode {
     MODE_SOLID_COLOR = 0,


### PR DESCRIPTION
This makes the backlight brightness up, down, and toggle keys work in a way that matches the EC. (I guess it shouldn't have 255 as the max; in which case the values will need to be adjusted).

The EC also has a color key. But what do we want here, since there are both colors and patterns that can be set?

I'm not sure this is really what we want (I guess it's just how Clevo decided to do things), but we'll want some kind of support for controlling the backlight through keys, and it makes sense to be consistent with the EC's behavior for internal keyboards.