### PR TITLE
RGB parameters per layer

### DIFF
--- a/keyboards/system76/launch_1/config.h
+++ b/keyboards/system76/launch_1/config.h
@@ -52,6 +52,7 @@
     #define RGB_MATRIX_STARTUP_HUE 142 // 200 degrees
     #define RGB_MATRIX_STARTUP_SAT 255
     #define RGB_MATRIX_STARTUP_VAL RGB_MATRIX_MAXIMUM_BRIGHTNESS
+    #define RGB_MATRIX_STARTUP_SPD 127
     #define RGB_MATRIX_DISABLE_KEYCODES // disables control of rgb matrix by keycodes (must use code functions to control the feature)
 #endif
 

--- a/keyboards/system76/launch_1/launch_1.c
+++ b/keyboards/system76/launch_1/launch_1.c
@@ -118,6 +118,14 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
     return process_record_user(keycode, record);
 }
 
+void system76_ec_rgb_layer(layer_state_t layer_state);
+
+layer_state_t layer_state_set_kb(layer_state_t layer_state) {
+    system76_ec_rgb_layer(layer_state);
+
+    return layer_state_set_user(layer_state);
+}
+
 void suspend_power_down_kb(void) {
     rgb_matrix_set_suspend_state(true);
     suspend_power_down_user();

--- a/keyboards/system76/launch_1/rgb_matrix_kb.inc
+++ b/keyboards/system76/launch_1/rgb_matrix_kb.inc
@@ -1,7 +1,55 @@
+RGB_MATRIX_EFFECT(active_keys)
 RGB_MATRIX_EFFECT(raw_rgb)
 RGB_MATRIX_EFFECT(unlocked)
 
 #if defined(RGB_MATRIX_CUSTOM_EFFECT_IMPLS)
+#include "dynamic_keymap.h"
+
+static bool active_keys_initialized = false;
+static uint8_t active_keys_table[DRIVER_LED_TOTAL] = { 0 };
+
+static void active_keys_initialize(void) {
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+            uint8_t led = g_led_config.matrix_co[row][col];
+            if (led < DRIVER_LED_TOTAL && row < 16 && col < 16) {
+                active_keys_table[led] = (row << 4) | col;
+            }
+        }
+    }
+    active_keys_initialized = true;
+}
+
+static bool active_keys(effect_params_t* params) {
+    if (!active_keys_initialized) {
+        active_keys_initialize();
+    }
+
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
+    uint8_t layer = get_highest_layer(layer_state);
+    RGB rgb = hsv_to_rgb(rgb_matrix_config.hsv);
+
+    for (uint8_t i = led_min; i < led_max; i++) {
+        RGB_MATRIX_TEST_LED_FLAGS();
+
+        uint8_t rowcol = active_keys_table[i];
+        uint8_t row = rowcol >> 4;
+        uint8_t col = rowcol & 0xF;
+        uint16_t keycode = dynamic_keymap_get_keycode(layer, row, col);
+        switch (keycode) {
+            case KC_NO:
+            case KC_TRNS:
+                rgb_matrix_set_color(i, 0, 0, 0);
+                break;
+            default:
+                rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
+                break;
+        }
+    }
+
+    return led_max < DRIVER_LED_TOTAL;
+}
+
 RGB raw_rgb_data[DRIVER_LED_TOTAL] = { 0 };
 
 static uint8_t normalize_component(uint8_t component) {

--- a/keyboards/system76/system76_ec.c
+++ b/keyboards/system76/system76_ec.c
@@ -48,6 +48,7 @@ enum Mode {
     MODE_RAINDROPS,
     MODE_SPLASH,
     MODE_MULTISPLASH,
+    MODE_ACTIVE_KEYS,
     MODE_LAST,
 };
 
@@ -65,6 +66,7 @@ static enum rgb_matrix_effects mode_map[] = {
     RGB_MATRIX_RAINDROPS,
     RGB_MATRIX_SPLASH,
     RGB_MATRIX_MULTISPLASH,
+    RGB_MATRIX_CUSTOM_active_keys,
 };
 
 _Static_assert(sizeof(mode_map) == MODE_LAST, "mode_map_length");

--- a/keyboards/system76/system76_ec.c
+++ b/keyboards/system76/system76_ec.c
@@ -34,6 +34,41 @@ enum Command {
     CMD_MATRIX_GET = 17,
 };
 
+#define CMD_LED_INDEX_ALL 0xFF
+
+static bool keymap_get(uint8_t layer, uint8_t output, uint8_t input, uint16_t *value) {
+    if (layer < dynamic_keymap_get_layer_count()) {
+        if (output < MATRIX_ROWS) {
+            if (input < MATRIX_COLS) {
+                *value = dynamic_keymap_get_keycode(layer, output, input);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static bool keymap_set(uint8_t layer, uint8_t output, uint8_t input, uint16_t value) {
+    if (layer < dynamic_keymap_get_layer_count()) {
+        if (output < MATRIX_ROWS) {
+            if (input < MATRIX_COLS) {
+                dynamic_keymap_set_keycode(layer, output, input, value);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static bool bootloader_reset = false;
+static bool bootloader_unlocked = false;
+
+void system76_ec_unlock(void) {
+    rgb_matrix_mode_noeeprom(RGB_MATRIX_CUSTOM_unlocked);
+    bootloader_unlocked = true;
+}
+
+#if defined(RGB_MATRIX_CUSTOM_KB)
 enum Mode {
     MODE_SOLID_COLOR = 0,
     MODE_PER_KEY,
@@ -71,41 +106,6 @@ static enum rgb_matrix_effects mode_map[] = {
 
 _Static_assert(sizeof(mode_map) == MODE_LAST, "mode_map_length");
 
-#define CMD_LED_INDEX_ALL 0xFF
-
-static bool keymap_get(uint8_t layer, uint8_t output, uint8_t input, uint16_t *value) {
-    if (layer < dynamic_keymap_get_layer_count()) {
-        if (output < MATRIX_ROWS) {
-            if (input < MATRIX_COLS) {
-                *value = dynamic_keymap_get_keycode(layer, output, input);
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-static bool keymap_set(uint8_t layer, uint8_t output, uint8_t input, uint16_t value) {
-    if (layer < dynamic_keymap_get_layer_count()) {
-        if (output < MATRIX_ROWS) {
-            if (input < MATRIX_COLS) {
-                dynamic_keymap_set_keycode(layer, output, input, value);
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-static bool bootloader_reset = false;
-static bool bootloader_unlocked = false;
-
-void system76_ec_unlock(void) {
-    rgb_matrix_mode_noeeprom(RGB_MATRIX_CUSTOM_unlocked);
-    bootloader_unlocked = true;
-}
-
-#if defined(RGB_MATRIX_CUSTOM_KB)
 RGB raw_rgb_data[DRIVER_LED_TOTAL];
 #endif // defined(RGB_MATRIX_CUSTOM_KB)
 


### PR DESCRIPTION
This will require ectool and configurator changes. Whole keyboard setting of mode and color is no longer supported. A layer parameter must be passed to the mode commands. See also https://github.com/system76/ec/pull/161