### PR TITLE
Feat: Adds sleep/shutdown LED 

### DIFF
--- a/keyboards/system76/launch_1/README.md
+++ b/keyboards/system76/launch_1/README.md
@@ -1,6 +1,6 @@
 ## Flashing firmware:
 * Clone this repository and `cd` into the `qmk_firmware` directory.
-* After cloning, you probably need to run `make git-submodule` as well as `./util/qmk_install`.
+* After cloning, you probably need to run `make git-submodule` as well as `./util/qmk_install.sh`.
    - You may also need to install dependencies: `sudo apt install avrdude gcc-avr avr-libc`
 * To build the firmware without flashing the keyboard, use `make (keyboard name):(layout name)`
    - For example, if you want to build the `default` layout for the Launch keyboard, run:

--- a/keyboards/system76/launch_1/config.h
+++ b/keyboards/system76/launch_1/config.h
@@ -33,6 +33,7 @@
     #define RGB_DI_PIN E2
     #define RGBLED_NUM 84
     #define RGBLIGHT_ANIMATIONS
+    #define RGBLIGHT_SLEEP
     // Limit brightness to support USB-A at 0.5A
     //TODO: do this dynamically based on power source
     #define RGBLIGHT_LIMIT_VAL 176


### PR DESCRIPTION
## Description

- Adds RGBLIGHT_SLEEP to the config.h file for the launch_1

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* LEDs do not turn off with the system and has to be disconnected from the system instead.
