### PR TITLE
Load layer state after initializing matrix

### DIFF
--- a/keyboards/system76/launch_1/launch_1.c
+++ b/keyboards/system76/launch_1/launch_1.c
@@ -137,7 +137,9 @@ void matrix_init_kb(void) {
     } else {
         system76_ec_rgb_eeprom(false);
     }
+}
 
+void keyboard_post_init_user(void) {
     system76_ec_rgb_layer(layer_state);
 }
 

--- a/keyboards/system76/launch_2/launch_2.c
+++ b/keyboards/system76/launch_2/launch_2.c
@@ -139,7 +139,9 @@ void matrix_init_kb(void) {
     } else {
         system76_ec_rgb_eeprom(false);
     }
+}
 
+void keyboard_post_init_user(void) {
     system76_ec_rgb_layer(layer_state);
 }
 

--- a/keyboards/system76/launch_heavy_1/launch_heavy_1.c
+++ b/keyboards/system76/launch_heavy_1/launch_heavy_1.c
@@ -152,7 +152,9 @@ void matrix_init_kb(void) {
     } else {
         system76_ec_rgb_eeprom(false);
     }
+}
 
+void keyboard_post_init_user(void) {
     system76_ec_rgb_layer(layer_state);
 }
 

--- a/keyboards/system76/launch_lite_1/launch_lite_1.c
+++ b/keyboards/system76/launch_lite_1/launch_lite_1.c
@@ -125,7 +125,9 @@ void matrix_init_kb(void) {
     } else {
         system76_ec_rgb_eeprom(false);
     }
+}
 
+void keyboard_post_init_user(void) {
     system76_ec_rgb_layer(layer_state);
 }
 


### PR DESCRIPTION
This fixes the issue, where layer 0 could have a lighting effect set to it. Then when plugging in the keyboard the lighting effect would show the default until the layer was changed, then switched back.

The custom lighting effect should now show when the keyboard is plugged in.