### PR TITLE
Retry

### DIFF
--- a/keyboards/system76/launch_2/config.h
+++ b/keyboards/system76/launch_2/config.h
@@ -63,9 +63,8 @@
 #define LOCKING_RESYNC_ENABLE
 
 // EEPROM {
-#define EEPROM_SIZE 1024
-
-// TODO: refactor with new user EEPROM code (coming soon)
+#define EEPROM_SIZE 2048
+// TODO: Refactor with new user EEPROM code (coming soon)
 #define EEPROM_MAGIC 0x76EC
 #define EEPROM_MAGIC_ADDR 64
 // Bump this every time we change what we store

--- a/keyboards/system76/launch_2/config.h
+++ b/keyboards/system76/launch_2/config.h
@@ -72,6 +72,7 @@
 // and avoid loading invalid data from the EEPROM
 #define EEPROM_VERSION 0x02
 #define EEPROM_VERSION_ADDR (EEPROM_MAGIC_ADDR + 2)
+#define EEPROM_USE_BOOTLOADER_ADDR (EEPROM_MAGIC_ADDR + 3)
 // } EEPROM
 
 // Dynamic keyboard support {

--- a/keyboards/system76/launch_2/launch_2.c
+++ b/keyboards/system76/launch_2/launch_2.c
@@ -115,10 +115,19 @@ void matrix_init_kb(void) {
     system76_ec_rgb_layer(layer_state);
 }
 
+extern bool jump_to_bootloader;
+
 void matrix_scan_kb(void) {
     usb_mux_event();
 
     matrix_scan_user();
+}
+
+void matrix_scan_user(void) {
+    if (jump_to_bootloader) {
+        wait_ms(100);
+        bootloader_jump();
+    }
 }
 
 #define LEVEL(value) (uint8_t)(\
@@ -259,7 +268,7 @@ void bootloader_jump(void) {
     PORTE  = 0;
     PORTF  = 0;
 
-    usb_mux_init(false);
+    usb_mux_init(true);
 
     // finally, jump to bootloader
     asm volatile("jmp 0xFC00");

--- a/keyboards/system76/launch_2/launch_2.c
+++ b/keyboards/system76/launch_2/launch_2.c
@@ -89,10 +89,9 @@ void bootmagic_lite(void) {
     // reset the EEPROM valid state and jump to bootloader.
     if ( matrix_get_row(0) & (1<<0) ) {
         eeprom_reset();
-        usb_mux_init();
         bootloader_jump();
     } else {
-        usb_mux_init();
+        usb_mux_init(true);
     }
 }
 
@@ -259,6 +258,8 @@ void bootloader_jump(void) {
     PORTD  = 0;
     PORTE  = 0;
     PORTF  = 0;
+
+    usb_mux_init(false);
 
     // finally, jump to bootloader
     asm volatile("jmp 0xFC00");

--- a/keyboards/system76/launch_2/usb_mux.c
+++ b/keyboards/system76/launch_2/usb_mux.c
@@ -425,7 +425,7 @@ void usb_mux_event(void) {
     }
 }
 
-void usb_mux_init(void) {
+void usb_mux_init(bool ensure_orientation) {
     // Put the USB hub in reset
     setPinOutput(GPIO_RESET_USB);
     writePinLow(GPIO_RESET_USB);
@@ -454,8 +454,10 @@ void usb_mux_init(void) {
 
     // Ensure orientation is correct after attaching hub
     //TODO: find reason why GPIO for sink orientation is reset
-    for(int i = 0; i < 100; i++) {
-        ptn5110_sink_set_orientation(&usb_sink);
-        _delay_ms(10);
+    if (ensure_orientation) {
+        for(int i = 0; i < 100; i++) {
+            ptn5110_sink_set_orientation(&usb_sink);
+            _delay_ms(10);
+        }
     }
 }

--- a/keyboards/system76/launch_2/usb_mux.c
+++ b/keyboards/system76/launch_2/usb_mux.c
@@ -425,7 +425,7 @@ void usb_mux_event(void) {
     }
 }
 
-void usb_mux_init(bool ensure_orientation) {
+void usb_mux_init(void) {
     // Put the USB hub in reset
     setPinOutput(GPIO_RESET_USB);
     writePinLow(GPIO_RESET_USB);
@@ -434,10 +434,10 @@ void usb_mux_init(bool ensure_orientation) {
     i2c_init(100000);
 
     // Sleep 10 ms, bring hub out of reset
-    _delay_ms(10);
+    wait_ms(10);
     writePinHigh(GPIO_RESET_USB);
     // Per Microchip support, wait 100 ms after reset with I2C idle
-    _delay_ms(100);
+    wait_ms(100);
 
     // Set up hub
     usb7006_init(&usb_hub);
@@ -454,10 +454,8 @@ void usb_mux_init(bool ensure_orientation) {
 
     // Ensure orientation is correct after attaching hub
     //TODO: find reason why GPIO for sink orientation is reset
-    if (ensure_orientation) {
-        for(int i = 0; i < 100; i++) {
-            ptn5110_sink_set_orientation(&usb_sink);
-            _delay_ms(10);
-        }
+    for(int i = 0; i < 100; i++) {
+        ptn5110_sink_set_orientation(&usb_sink);
+        wait_ms(10);
     }
 }

--- a/keyboards/system76/launch_2/usb_mux.h
+++ b/keyboards/system76/launch_2/usb_mux.h
@@ -1,7 +1,7 @@
 #ifndef USB_MUX_H
 #define USB_MUX_H
 
-void usb_mux_init(void);
+void usb_mux_init(bool ensure_orientation);
 void usb_mux_event(void);
 
 #endif // USB_MUX_H

--- a/keyboards/system76/launch_2/usb_mux.h
+++ b/keyboards/system76/launch_2/usb_mux.h
@@ -1,7 +1,7 @@
 #ifndef USB_MUX_H
 #define USB_MUX_H
 
-void usb_mux_init(bool ensure_orientation);
+void usb_mux_init(void);
 void usb_mux_event(void);
 
 #endif // USB_MUX_H

--- a/keyboards/system76/launch_heavy_1/launch_heavy_1.c
+++ b/keyboards/system76/launch_heavy_1/launch_heavy_1.c
@@ -93,10 +93,9 @@ void bootmagic_lite(void) {
     // reset the EEPROM valid state and jump to bootloader.
     if ( matrix_get_row(0) & (1<<0) ) {
         eeprom_reset();
-        usb_mux_init();
         bootloader_jump();
     } else {
-        usb_mux_init();
+        usb_mux_init(true);
     }
 }
 
@@ -263,6 +262,8 @@ void bootloader_jump(void) {
     PORTD  = 0;
     PORTE  = 0;
     PORTF  = 0;
+
+    usb_mux_init(false);
 
     // finally, jump to bootloader
     asm volatile("jmp 0xFC00");

--- a/keyboards/system76/launch_heavy_1/usb_mux.c
+++ b/keyboards/system76/launch_heavy_1/usb_mux.c
@@ -425,7 +425,7 @@ void usb_mux_event(void) {
     }
 }
 
-void usb_mux_init(void) {
+void usb_mux_init(bool ensure_orientation) {
     // Run I2C bus at 100 KHz
     i2c_init(100000);
 
@@ -451,8 +451,10 @@ void usb_mux_init(void) {
 
     // Ensure orientation is correct after attaching hub
     //TODO: find reason why GPIO for sink orientation is reset
-    for(int i = 0; i < 100; i++) {
-        ptn5110_sink_set_orientation(&usb_sink);
-        _delay_ms(10);
+    if (ensure_orientation) {
+        for(int i = 0; i < 100; i++) {
+            ptn5110_sink_set_orientation(&usb_sink);
+            _delay_ms(10);
+        }
     }
 }

--- a/keyboards/system76/launch_heavy_1/usb_mux.h
+++ b/keyboards/system76/launch_heavy_1/usb_mux.h
@@ -1,7 +1,7 @@
 #ifndef USB_MUX_H
 #define USB_MUX_H
 
-void usb_mux_init(void);
+void usb_mux_init(bool ensure_orientation);
 void usb_mux_event(void);
 
 #endif // USB_MUX_H

--- a/keyboards/system76/system76_ec.c
+++ b/keyboards/system76/system76_ec.c
@@ -39,6 +39,7 @@ enum Command {
 };
 
 bool input_disabled = false;
+bool jump_to_bootloader = false;
 
 #define CMD_LED_INDEX_ALL 0xFF
 
@@ -66,7 +67,6 @@ static bool keymap_set(uint8_t layer, uint8_t output, uint8_t input, uint16_t va
     return false;
 }
 
-static bool bootloader_reset = false;
 static bool bootloader_unlocked = false;
 
 void system76_ec_unlock(void) {
@@ -247,7 +247,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
         case CMD_RESET:
             if (bootloader_unlocked) {
                 data[1] = 0;
-                bootloader_reset = true;
+                jump_to_bootloader = true;
             }
             break;
         case CMD_KEYMAP_GET:
@@ -420,11 +420,4 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
     }
 
     raw_hid_send(data, length);
-
-    if (bootloader_reset) {
-        // Give host time to read response
-        wait_ms(100);
-        // Jump to the bootloader
-        bootloader_jump();
-    }
 }


### PR DESCRIPTION
Requires unplugging + replugging keyboard for fwupd updates. Is this good enough? Will require changing the fwupd update message at least.
Changing from `_delay_ms` to the non-blocking `wait_ms` in `usb_mux.c` also helps improve successful bootloader frequency.

Easy to-dos if we decide to use this PR:
- [ ] C directive in system76_ec.c to only do this on launch_(2|heavy_1). (Other models shouldn't be affected by this)
- [ ] Copy changes to launch_heavy_1